### PR TITLE
update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,78 @@
-# Python-generated files
+# Byte-compiled / optimized / DLL files
 __pycache__/
-*.py[oc]
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
 build/
 dist/
 wheels/
-*.egg-info
-.idea/
+*.egg-info/
+.eggs/
+MANIFEST
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# PyBuilder
+target/
 
 # Virtual environments
-.venv
+.venv/
+venv/
+ENV/
+env/
+env.bak/
+
+# IDE / editor settings
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# Environment / local config
+*.env
+.env.*


### PR DESCRIPTION
I’ve updated the .gitignore as requested in issue #29:

- Added ignores for Python build artifacts and bytecode (__pycache__, *.pyc, build/, dist/, *.egg-info, etc.).
- Added ignores for virtual environments (.venv/, venv/, env/, ENV/).
- Added ignores for IDE/editor configs, including .vscode/ and .idea/.
- Added common OS-specific and local config files (.DS_Store, *.env, etc.).

This should keep editor settings and generated files out of the repository.
