### PR TITLE
docs: add clickable link to CONTRIBUTING.md in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,4 +287,4 @@ def my_cron_task() -> None:
 
 ### Contributing
 
-See `CONTRIBUTING.md`
+See [contribution guide](CONTRIBUTING.md)


### PR DESCRIPTION
Fixes #36

Changed `See `CONTRIBUTING.md`` to `See [contribution guide](CONTRIBUTING.md)` in the Contributing section of the README, making it a clickable link as requested.