### PR TITLE
fix: correct .dalay() to .delay() and .execute() to .delay() in task delaying docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,10 +174,10 @@ After your tasks declaration, you are able to delay your tasks for next executio
 
 ```python
 # async
-await async_task(string_param='I am async task with 15 sec coundown').dalay(countdown=15)
+await async_task(string_param='I am async task with 15 sec coundown').delay(countdown=15)
 
 # sync
-sync_task(string_param='I am sync task with 30 sec coundown').execute(countdown=30)
+sync_task(string_param='I am sync task with 30 sec coundown').delay(countdown=30)
 ```
 
 Attention: at the moment you can delay tasks for a maximum of 24 hours. Longer delays will come with postgres/rabbitmq/kafka brokers. For now, consider using Postgres (e.g., with Celery) for long-lived task storage.


### PR DESCRIPTION
Closes #38

Fixed two typos in the Task delaying section of README.md:
- `.dalay(countdown=15)` → `.delay(countdown=15)`
- `.execute(countdown=30)` → `.delay(countdown=30)`