### PR TITLE
fix: await asyncio.sleep and start_consume in docstring examples

### DIFF
--- a/melony/core/brokers.py
+++ b/melony/core/brokers.py
@@ -83,7 +83,7 @@ class BaseBroker(ABC):
 
             >>> @broker.task
             >>> async def example_task(string_param: str) -> str:
-            ...     asyncio.sleep(2)
+            ...     await asyncio.sleep(2)
             ...     return string_param.upper()
 
         Now you have opportunity to call special method for execute your task after some

--- a/melony/redis_broker/brokers.py
+++ b/melony/redis_broker/brokers.py
@@ -108,10 +108,10 @@ class RedisBroker(BaseBroker):
 
             >>> @broker.task
             >>> async def example_task(string_param: str) -> str:
-            >>>     asyncio.sleep(2)
+            >>>     await asyncio.sleep(2)
             >>>     return string_param.upper()
 
-            >>> broker.consumer.start_consume()  # Run consuming process.
+            >>> await broker.consumer.start_consume()  # Run consuming process.
 
         Also you are able to provide 'processes' parameter for choosing number of processes
         (workers).


### PR DESCRIPTION
Fixes #40

- Added missing `await` before `asyncio.sleep(2)` in `core/brokers.py` docstring
- Added missing `await` before `asyncio.sleep(2)` in `redis_broker/brokers.py` docstring  
- Added missing `await` before `broker.consumer.start_consume()` in `redis_broker/brokers.py` docstring